### PR TITLE
Fix Database Schema

### DIFF
--- a/data/schema.sql
+++ b/data/schema.sql
@@ -417,7 +417,7 @@ CREATE TYPE SessionChannelType AS ENUM (
   'STANDARD',
   'ACCOUNTABILITY',
   'RENTED',
-  'EXTERNAL',
+  'EXTERNAL'
 );
 
 


### PR DESCRIPTION
Extra ',' resulting in errors when freshly reconstructing lionbot DB.

Error Log:
```sql
CREATE TABLE
INSERT 0 1
CREATE FUNCTION
CREATE TABLE
CREATE TABLE
CREATE TABLE
CREATE TABLE
CREATE TABLE
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE VIEW
CREATE TYPE
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE TABLE
CREATE VIEW
CREATE TABLE
CREATE INDEX
CREATE TYPE
CREATE TYPE
CREATE TABLE
CREATE INDEX
CREATE INDEX
CREATE VIEW
ALTER TABLE
ALTER TABLE
ALTER TABLE
CREATE FUNCTION
CREATE TRIGGER
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TRIGGER
schema.sql:421: ERROR: syntax error at or near ")"
LINE 11: );
^
schema.sql:439: ERROR: type "sessionchanneltype" does not exist
LINE 11: channel_type SessionChannelType,
^
schema.sql:440: ERROR: relation "session_history" does not exist
schema.sql:459: ERROR: type "sessionchanneltype" does not exist
LINE 9: channel_type SessionChannelType,
^
schema.sql:460: ERROR: relation "current_sessions" does not exist
CREATE FUNCTION
CREATE FUNCTION
schema.sql:545: ERROR: relation "current_sessions" does not exist
LINE 15: FROM current_sessions;
^
schema.sql:555: ERROR: relation "current_sessions_totals" does not exist
LINE 15: LEFT JOIN current_sessions_totals sesh USING (guildid, use...
^
schema.sql:563: ERROR: relation "members_totals" does not exist
LINE 11: FROM members_totals;
^
schema.sql:575: ERROR: relation "members_totals" does not exist
LINE 17: FROM members_totals;
^
schema.sql:583: ERROR: relation "current_study_badges" does not exist
LINE 7: FROM current_study_badges
^
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE INDEX
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE INDEX
CREATE VIEW
CREATE VIEW
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
CREATE TABLE
CREATE INDEX
Total runtime: 355.634 ms

SQL executed.
```